### PR TITLE
Set timeout for rpc of prevote and request_vote; Reset random range of election_timeout

### DIFF
--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -513,7 +513,7 @@ public:
     void reset_election_timeout_ms(int election_timeout_ms);
 
     // Try transfering leadership to |peer|.
-    // If peer is ANY_PEER, a proper follower will be chosen as the leader the
+    // If peer is ANY_PEER, a proper follower will be chosen as the leader for
     // the next term.
     // Returns 0 on success, -1 otherwise.
     int transfer_leadership_to(const PeerId& peer);


### PR DESCRIPTION

1. set timeout of prevote_rpc and request_vote_rpc to election_timeout_ms
instead of default value 500ms, in case of timed out too quickly for sata disks.
2. add a gflag raft_max_election_delay_ms, which allows user to define
election_timeout random margin.