### PR TITLE
Ss18/Enhancements

### DIFF
--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -108,7 +108,7 @@ class Iterator {
     bool valid() const;
     // Invoked when some critical error occurred. And we will consider the last 
     // |ntail| tasks (starting from the last iterated one) as not applied. After
-    // this point, no futher changes on the StateMachine as well as the Node 
+    // this point, no further changes on the StateMachine as well as the Node 
     // would be allowed and you should try to repair this replica or just drop 
     // it.
     //

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -159,7 +159,7 @@ struct NodeOptions {
     // Default: A empty group
     Configuration initial_conf;
 
-    // The specific StateMachine implemented your bussiness logic, which must be
+    // The specific StateMachine implemented your business logic, which must be
     // a valid instance.
     StateMachine* fsm;
 

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -104,9 +104,9 @@ class Iterator {
     Closure* done() const;
     // Return true this iterator is currently references to a valid task, false
     // otherwise, indicating that the iterator has reached the end of this
-    // batch of tasks or some error has occured
+    // batch of tasks or some error has occurred
     bool valid() const;
-    // Invoked when some critical error occured. And we will consider the last 
+    // Invoked when some critical error occurred. And we will consider the last 
     // |ntail| tasks (starting from the last iterated one) as not applied. After
     // this point, no futher changes on the StateMachine as well as the Node 
     // would be allowed and you should try to repair this replica or just drop 
@@ -298,7 +298,7 @@ class StateMachine {
     // Invoked when this node is no longer the leader of the belonging group.
     // |status| describes more details about the reason.
     virtual void on_leader_stop(const butil::Status& status);
-    // Invoked when some critical error occured and this Node stops working 
+    // Invoked when some critical error occurred and this Node stops working 
     // ever after.  
     virtual void on_error(const ::braft::Error& e);
     // Invoked when a configuration has been committed to the group

--- a/docs/cn/server.md
+++ b/docs/cn/server.md
@@ -488,7 +488,7 @@ void add_peer(const std::vector<PeerId>& old_peers, const PeerId& peer, Closure*
 ## 转移Leader
 
 ```
-// Try transfering leadership to |peer|.
+// Try transferring leadership to |peer|.
 // If peer is ANY_PEER, a proper follower will be chosen as the leader the
 // the next term.
 // Returns 0 on success, -1 otherwise.

--- a/example/atomic/server.cpp
+++ b/example/atomic/server.cpp
@@ -320,7 +320,7 @@ friend class AtomicClosure;
         int64_t id = 0;
         if (request) {
             // This task is applied by this node, get value from this
-            // closure to avoid addtional parsing.
+            // closure to avoid additional parsing.
             id = dynamic_cast<const GetRequest*>(request)->id();
         } else {
             butil::IOBufAsZeroCopyInputStream wrapper(data);
@@ -342,7 +342,7 @@ friend class AtomicClosure;
         int64_t value = 0;
         if (request) {
             // This task is applied by this node, get value from this
-            // closure to avoid addtional parsing.
+            // closure to avoid additional parsing.
             const ExchangeRequest* req
                     = dynamic_cast<const ExchangeRequest*>(request);
             id = req->id();
@@ -370,7 +370,7 @@ friend class AtomicClosure;
         int64_t expected = 0;
         if (request) {
             // This task is applied by this node, get value from this
-            // closure to avoid addtional parsing.
+            // closure to avoid additional parsing.
             const CompareExchangeRequest* req =
                     dynamic_cast<const CompareExchangeRequest*>(request);
             id = req->id();

--- a/example/block/server.cpp
+++ b/example/block/server.cpp
@@ -178,7 +178,7 @@ public:
         const ssize_t nr = braft::file_pread(
                 &portal, fd->fd(), request->offset(), request->size());
         if (nr < 0) {
-            // Some disk error occured, shutdown this node and another leader
+            // Some disk error occurred, shutdown this node and another leader
             // will be elected
             PLOG(ERROR) << "Fail to read from fd=" << fd->fd();
             _node->shutdown(NULL);
@@ -292,7 +292,7 @@ friend class BlockClosure;
                 }
                 // Let raft run this closure.
                 closure_guard.release();
-                // Some disk error occured, notify raft and never apply any data
+                // Some disk error occurred, notify raft and never apply any data
                 // ever after
                 iter.set_error_and_rollback();
                 return;

--- a/example/block/server.cpp
+++ b/example/block/server.cpp
@@ -262,7 +262,7 @@ friend class BlockClosure;
             off_t offset = 0;
             if (iter.done()) {
                 // This task is applied by this node, get value from this
-                // closure to avoid addtional parsing.
+                // closure to avoid additional parsing.
                 BlockClosure* c = dynamic_cast<BlockClosure*>(iter.done());
                 offset = c->request()->offset();
                 data.swap(*(c->data()));

--- a/example/counter/server.cpp
+++ b/example/counter/server.cpp
@@ -191,7 +191,7 @@ friend class FetchAddClosure;
             braft::AsyncClosureGuard closure_guard(iter.done());
             if (iter.done()) {
                 // This task is applied by this node, get value from this
-                // closure to avoid addtional parsing.
+                // closure to avoid additional parsing.
                 FetchAddClosure* c = dynamic_cast<FetchAddClosure*>(iter.done());
                 response = c->response();
                 detal_value = c->request()->value();

--- a/example/shflags
+++ b/example/shflags
@@ -756,7 +756,7 @@ _flags_parseGetopt()
       fi
     fi
 
-    # shift the option and non-boolean arguements out.
+    # shift the option and non-boolean arguments out.
     shift
     [ ${_flags_type_} != ${__FLAGS_TYPE_BOOLEAN} ] && shift
   done

--- a/example/shflags
+++ b/example/shflags
@@ -424,7 +424,7 @@ _flags_getFlagInfo()
   return ${flags_return}
 }
 
-# check for presense of item in a list. passed a string (e.g. 'abc'), this
+# check for presence of item in a list. passed a string (e.g. 'abc'), this
 # function will determine if the string is present in the list of strings (e.g.
 # ' foo bar abc ').
 #
@@ -780,7 +780,7 @@ _flags_parseGetopt()
 # A basic boolean flag. Boolean flags do not take any arguments, and their
 # value is either 1 (false) or 0 (true). For long flags, the false value is
 # specified on the command line by prepending the word 'no'. With short flags,
-# the presense of the flag toggles the current value between true and false.
+# the presence of the flag toggles the current value between true and false.
 # Specifying a short boolean flag twice on the command results in returning the
 # value back to the default value.
 #

--- a/src/braft/fsm_caller.cpp
+++ b/src/braft/fsm_caller.cpp
@@ -255,7 +255,7 @@ void FSMCaller::do_committed(int64_t committed_index) {
         if (iter_impl.entry()->type != ENTRY_TYPE_DATA) {
             if (iter_impl.entry()->type == ENTRY_TYPE_CONFIGURATION) {
                 if (iter_impl.entry()->old_peers != NULL) {
-                    // Joint stage is not supposed to be noticable by end users.
+                    // Joint stage is not supposed to be noticeable by end users.
                     _fsm->on_configuration_committed(
                             Configuration(*iter_impl.entry()->peers));
                 }
@@ -385,7 +385,7 @@ void FSMCaller::do_snapshot_load(LoadSnapshotClosure* done) {
     }
 
     if (meta.old_peers_size() == 0) {
-        // Joint stage is not supposed to be noticable by end users.
+        // Joint stage is not supposed to be noticeable by end users.
         Configuration conf;
         for (int i = 0; i < meta.peers_size(); ++i) {
             conf.add_peer(meta.peers(i));

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -714,7 +714,7 @@ int SegmentLogStorage::append_entries(const std::vector<LogEntry*>& entries) {
     }
     if (_last_log_index.load(butil::memory_order_relaxed) + 1
             != entries.front()->id.index) {
-        LOG(FATAL) << "There's gap betwenn appending entries and _last_log_index";
+        LOG(FATAL) << "There's gap between appending entries and _last_log_index";
         return -1;
     }
     scoped_refptr<Segment> last_segment = NULL;

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -627,7 +627,7 @@ void NodeImpl::on_caughtup(const PeerId& peer, int64_t term,
         return;
     }
 
-    if (st.ok()) {  // Caught up succesfully
+    if (st.ok()) {  // Caught up successfully
         _conf_ctx.on_caughtup(version, peer, true);
         return;
     }

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -848,7 +848,7 @@ void NodeImpl::shutdown(Closure* done) {
 
         if (_state < STATE_SHUTTING) {  // Got the right to shut
             // Remove node from NodeManager and |this| would not be accessed by
-            // the comming RPCs
+            // the coming RPCs
             NodeManager::GetInstance()->remove(this);
             // if it is leader, set the wakeup_a_candidate with true,
             // if it is follower, call on_stop_following in step_down

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -1397,7 +1397,7 @@ void NodeImpl::elect_self(std::unique_lock<raft_mutex_t>* lck) {
     lck->lock();
     // vote need defense ABA after unlock&lock
     if (old_term != _current_term) {
-        // term changed casue by step_down
+        // term changed cause by step_down
         LOG(WARNING) << "node " << _group_id << ":" << _server_id
             << " raise term " << _current_term << " when get last_log_id";
         return;

--- a/src/braft/node.cpp
+++ b/src/braft/node.cpp
@@ -716,7 +716,7 @@ void NodeImpl::unsafe_register_conf_change(const Configuration& old_conf,
                      << state2str(_state) ;
         if (done) {
             if (_state == STATE_TRANSFERING) {
-                done->status().set_error(EBUSY, "Is transfering leadership");
+                done->status().set_error(EBUSY, "Is transferring leadership");
             } else {
                 done->status().set_error(EPERM, "Not leader");
             }
@@ -1068,7 +1068,7 @@ int NodeImpl::transfer_leadership_to(const PeerId& peer) {
         }
     }
     if (peer_id == _server_id) {
-        LOG(INFO) << "Transfering leadership to self";
+        LOG(INFO) << "Transferring leadership to self";
         return 0;
     }
     if (!_conf.contains(peer_id)) {
@@ -1085,7 +1085,7 @@ int NodeImpl::transfer_leadership_to(const PeerId& peer) {
     }
     _state = STATE_TRANSFERING;
     butil::Status status;
-    status.set_error(ETRANSFERLEADERSHIP, "Raft leader is transfering "
+    status.set_error(ETRANSFERLEADERSHIP, "Raft leader is transferring "
             "leadership to %s", peer_id.to_string().c_str());
     _fsm_caller->on_leader_stop(status);
     LOG(INFO) << "node " << _group_id << ":" << _server_id
@@ -1640,7 +1640,7 @@ void NodeImpl::apply(LogEntryAndClosure tasks[], size_t size) {
         if (_state != STATE_TRANSFERING) {
             st.set_error(EPERM, "is not leader");
         } else {
-            st.set_error(EBUSY, "is transfering leadership");
+            st.set_error(EBUSY, "is transferring leadership");
         }
         lck.unlock();
         BRAFT_VLOG << "node " << _group_id << ":" << _server_id << " can't apply : " << st;

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -169,7 +169,7 @@ public:
 
     // Invoked when some critical error occurred. And we will consider the last 
     // |ntail| tasks (starting from the last iterated one) as not applied. After
-    // this point, no futher changes on the StateMachine as well as the Node 
+    // this point, no further changes on the StateMachine as well as the Node 
     // would be allowed and you should try to repair this replica or just drop 
     // it.
     //

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -512,7 +512,7 @@ public:
     // reset the election_timeout for the very node
     void reset_election_timeout_ms(int election_timeout_ms);
 
-    // Try transfering leadership to |peer|.
+    // Try transferring leadership to |peer|.
     // If peer is ANY_PEER, a proper follower will be chosen as the leader for
     // the next term.
     // Returns 0 on success, -1 otherwise.

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -186,7 +186,7 @@ friend class FSMCaller;
 };
 
 // |StateMachine| is the sink of all the events of a very raft node.
-// Implement a specific StateMachine for your own bussiness logic.
+// Implement a specific StateMachine for your own business logic.
 //
 // NOTE: All the interfaces are not guaranteed to be thread safe and they are 
 // called sequentially, saying that every single operation will block all the 
@@ -380,7 +380,7 @@ struct NodeOptions {
     // Default: A empty group
     Configuration initial_conf;
 
-    // The specific StateMachine implemented your bussiness logic, which must be
+    // The specific StateMachine implemented your business logic, which must be
     // a valid instance.
     StateMachine* fsm;
 

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -267,7 +267,7 @@ public:
 enum State {
     // Don't change the order if you are not sure about the usage.
     STATE_LEADER = 1,
-    STATE_TRANSFERING = 2,
+    STATE_TRANSFERRING = 2,
     STATE_CANDIDATE = 3,
     STATE_FOLLOWER = 4,
     STATE_ERROR = 5,

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -278,7 +278,7 @@ enum State {
 };
 
 inline const char* state2str(State state) {
-    const char* str[] = {"LEADER", "TRANSFERING", "CANDIDATE", "FOLLOWER", 
+    const char* str[] = {"LEADER", "TRANSFERRING", "CANDIDATE", "FOLLOWER", 
                          "ERROR", "UNINITIALIZED", "SHUTTING", "SHUTDOWN", };
     if (state < STATE_END) {
         return str[(int)state - 1];

--- a/src/braft/raft.h
+++ b/src/braft/raft.h
@@ -164,10 +164,10 @@ public:
 
     // Return true this iterator is currently references to a valid task, false
     // otherwise, indicating that the iterator has reached the end of this
-    // batch of tasks or some error has occured
+    // batch of tasks or some error has occurred
     bool valid() const;
 
-    // Invoked when some critical error occured. And we will consider the last 
+    // Invoked when some critical error occurred. And we will consider the last 
     // |ntail| tasks (starting from the last iterated one) as not applied. After
     // this point, no futher changes on the StateMachine as well as the Node 
     // would be allowed and you should try to repair this replica or just drop 

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -551,7 +551,7 @@ int Replicator::_continue_sending(void* arg, int error_code) {
     if (error_code == ETIMEDOUT) {
         // Send empty entries after block timeout to check the correct
         // _next_index otherwise the replictor is likely waits in
-        // _wait_more_entries and no futher logs would be replicated even if the
+        // _wait_more_entries and no further logs would be replicated even if the
         // last_index of this followers is less than |next_index - 1|
         r->_send_empty_entries(false);
     } else if (error_code != ESTOP) {

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -937,7 +937,7 @@ int64_t Replicator::get_next_index(ReplicatorId id) {
 void Replicator::_destroy() {
     bthread_id_t saved_id = _id;
     CHECK_EQ(0, bthread_id_unlock_and_destroy(saved_id));
-    // TODO: Add more infomation
+    // TODO: Add more information
     LOG(INFO) << "Replicator=" << saved_id << " is going to quit";
     delete this;
 }

--- a/src/braft/replicator.cpp
+++ b/src/braft/replicator.cpp
@@ -691,7 +691,7 @@ void Replicator::_on_install_snapshot_returned(
     return r->_send_entries();
 }
 
-void Replicator::_notify_on_caught_up(int error_code, bool before_destory) {
+void Replicator::_notify_on_caught_up(int error_code, bool before_destroy) {
     if (_catchup_closure == NULL) {
         return;
     }
@@ -708,7 +708,7 @@ void Replicator::_notify_on_caught_up(int error_code, bool before_destory) {
             _catchup_closure->status().set_error(error_code, "%s", berror(error_code));
         }
         if (_catchup_closure->_has_timer) {
-            if (!before_destory && bthread_timer_del(_catchup_closure->_timer) == 1) {
+            if (!before_destroy && bthread_timer_del(_catchup_closure->_timer) == 1) {
                 // There's running timer task, let timer task trigger
                 // on_caught_up to void ABA problem
                 return;

--- a/src/braft/replicator.h
+++ b/src/braft/replicator.h
@@ -264,7 +264,7 @@ public:
     // Transfer leadership to the given |peer|
     int transfer_leadership_to(const PeerId& peer, int64_t log_index);
 
-    // Stop transfering leadership to the given |peer|
+    // Stop transferring leadership to the given |peer|
     int stop_transfer_leadership(const PeerId& peer);
 
     // Stop all the replicators except for the one that we think can be the

--- a/src/braft/snapshot_executor.cpp
+++ b/src/braft/snapshot_executor.cpp
@@ -303,7 +303,7 @@ void SaveSnapshotDone::Run() {
     // Avoid blocking FSMCaller
     // This continuation of snapshot saving is likely running inplace where the
     // on_snapshot_save is called (in the FSMCaller thread) and blocks all the
-    // following on_apply. As blocking is not neccessary and the continuation is
+    // following on_apply. As blocking is not necessary and the continuation is
     // not important, so we start a bthread to do this.
     bthread_t tid;
     if (bthread_start_urgent(&tid, NULL, continue_run, this) != 0) {

--- a/src/braft/util.cpp
+++ b/src/braft/util.cpp
@@ -90,10 +90,10 @@ ssize_t file_pwrite(const butil::IOBuf& data, int fd, off_t offset) {
     off_t orig_offset = offset;
     ssize_t left = size;
     while (left > 0) {
-        ssize_t writen = piece_data.pcut_into_file_descriptor(fd, offset, left);
-        if (writen >= 0) {
-            offset += writen;
-            left -= writen;
+        ssize_t written = piece_data.pcut_into_file_descriptor(fd, offset, left);
+        if (written >= 0) {
+            offset += written;
+            left -= written;
         } else if (errno == EINTR) {
             continue;
         } else {

--- a/test/memory_file_system_adaptor.h
+++ b/test/memory_file_system_adaptor.h
@@ -1,4 +1,4 @@
-// libraft - Quorum-based replication of states accross machines.
+// libraft - Quorum-based replication of states across machines.
 // Copyright (c) 2017 Baidu.com, Inc. All Rights Reserved
 
 // Author: ZhengPengFei (zhengpengfei@baidu.com)

--- a/test/test_file_service.cpp
+++ b/test/test_file_service.cpp
@@ -82,8 +82,8 @@ TEST_F(FileServiceTest, hole_file) {
     for (int i = 0; i < 1000; i++) {
         char buf[16*1024] = {0};
         snprintf(buf, sizeof(buf), "hello %d", i);
-        ssize_t nwriten = pwrite(fd, buf, strlen(buf), 128 * 1024 * i);
-        ASSERT_EQ(static_cast<size_t>(nwriten), strlen(buf));
+        ssize_t nwritten = pwrite(fd, buf, strlen(buf), 128 * 1024 * i);
+        ASSERT_EQ(static_cast<size_t>(nwritten), strlen(buf));
     }
     ::close(fd);
     braft::FileSystemAdaptor* fs = braft::default_file_system();

--- a/test/test_file_system_adaptor.cpp
+++ b/test/test_file_system_adaptor.cpp
@@ -1,4 +1,4 @@
-// libraft - Quorum-based replication of states accross machines.
+// libraft - Quorum-based replication of states across machines.
 // Copyright (c) 2017 Baidu.com, Inc. All Rights Reserved
 
 // Author: ZhengPengFei (zhengpengfei@baidu.com)

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -1,4 +1,4 @@
-// libraft - Quorum-based replication of states accross machines.
+// libraft - Quorum-based replication of states across machines.
 // Copyright (c) 2015 Baidu.com, Inc. All Rights Reserved
 
 // Author: WangYao (fisherman), wangyao02@baidu.com

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -707,7 +707,7 @@ void* read_thread_routine(void* arg) {
 
 void* write_thread_routine(void* arg) {
     braft::SegmentLogStorage* storage = (braft::SegmentLogStorage*)arg;
-    // Write operation distrubution: 
+    // Write operation distribution: 
     //  - 10% truncate_prefix
     //  - 10% truncate_suffix,
     //  - 30% increase last_read_index (which stands for committment in the real

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -710,7 +710,7 @@ void* write_thread_routine(void* arg) {
     // Write operation distribution: 
     //  - 10% truncate_prefix
     //  - 10% truncate_suffix,
-    //  - 30% increase last_read_index (which stands for committment in the real
+    //  - 30% increase last_read_index (which stands for commitment in the real
     // world), 
     //  - 50% append new entry
     int next_log_index = storage->last_log_index() + 1;

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -1,4 +1,4 @@
-// libraft - Quorum-based replication of states accross machines.
+// libraft - Quorum-based replication of states across machines.
 // Copyright (c) 2015 Baidu.com, Inc. All Rights Reserved
 
 // Author: WangYao (fisherman), wangyao02@baidu.com

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -2256,11 +2256,11 @@ TEST_F(NodeTest, on_start_following_and_on_stop_following) {
     ASSERT_EQ(followers_second.size(), 3);
     // leader_third's _on_start_following_times and _on_stop_following_times should both be 2.
     // When it was still in follower state, it would do handle_timeout_now_request and
-    // trigger on_stop_following when leader_second transfered leadership to it.
+    // trigger on_stop_following when leader_second transferred leadership to it.
     ASSERT_EQ(static_cast<MockFSM*>(leader_third->_impl->_options.fsm)->_on_start_following_times, 2);
     ASSERT_EQ(static_cast<MockFSM*>(leader_third->_impl->_options.fsm)->_on_start_following_times, 2);
     for (int i = 0; i < 3; i++) {
-        // leader_second became follower when it transfered leadership to target, 
+        // leader_second became follower when it transferred leadership to target, 
         // and when it receives leader_third's append_entries_request on_start_following is triggled.
         if (followers_third[i]->node_id().peer_id == leader_second->node_id().peer_id) {
             ASSERT_EQ(static_cast<MockFSM*>(followers_third[i]->_impl->_options.fsm)->_on_start_following_times, 2);

--- a/test/test_snapshot.cpp
+++ b/test/test_snapshot.cpp
@@ -1,4 +1,4 @@
-// libraft - Quorum-based replication of states accross machines.
+// libraft - Quorum-based replication of states across machines.
 // Copyright (c) 2015 Baidu.com, Inc. All Rights Reserved
 
 // Author: WangYao (fisherman), wangyao02@baidu.com

--- a/test/test_throttle.cpp
+++ b/test/test_throttle.cpp
@@ -1,4 +1,4 @@
-// libraft - Quorum-based replication of states accross machines.
+// libraft - Quorum-based replication of states across machines.
 // Copyright (c) 2017 Baidu.com, Inc. All Rights Reserved
 
 // Author: Xiong Kai (xiongkai@baidu.com)

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -82,8 +82,8 @@ TEST_F(TestUsageSuits, pread_pwrite) {
 
     butil::IOBuf data;
     data.append("hello");
-    ssize_t nwriten = braft::file_pwrite(data, fd, 1000);
-    ASSERT_EQ(nwriten, data.size());
+    ssize_t nwritten = braft::file_pwrite(data, fd, 1000);
+    ASSERT_EQ(nwritten, data.size());
 
     portal.clear();
     nread = braft::file_pread(&portal, fd, 1000, 10);

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -1,4 +1,4 @@
-// libraft - Quorum-based replication of states accross machines.
+// libraft - Quorum-based replication of states across machines.
 // Copyright (c) 2015 Baidu.com, Inc. All Rights Reserved
 
 // Author: WangYao (fisherman), wangyao02@baidu.com


### PR DESCRIPTION
Done with https://github.com/ss18/grep-typos

Fixed typos:
transfering -> transferring
STATE_TRANSFERING -> STATE_TRANSFERRING
transfered -> transferred
writen -> written
succesfully -> successfully
presense -> presence
neccessary -> necessary
occured -> occurred
noticable -> noticeable
infomation -> information
futher -> further
before_destory -> before_destroy
distrubution -> distribution
bussiness -> business
casue -> cause
comming -> coming
committment -> commitment
betwenn -> between
addtional -> additional
arguements -> arguments
accross -> across