### PR TITLE
Fix bug in log.cpp

### DIFF
--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -985,7 +985,7 @@ int SegmentLogStorage::list_segments(bool is_empty) {
     SegmentMap::iterator it;
     for (it = _segments.begin(); it != _segments.end();) {
         Segment* segment = it->second.get();
-        if (segment->first_index() >= segment->last_index()) {
+        if (segment->first_index() > segment->last_index()) {
             LOG(WARNING) << "closed segment is bad, path: " << _path
                 << " first_index: " << segment->first_index()
                 << " last_index: " << segment->last_index();

--- a/test/test_cli.cpp
+++ b/test/test_cli.cpp
@@ -173,12 +173,13 @@ TEST_F(CliTest, change_peer) {
     }
     butil::Status st;
     for (size_t i = 0; i < N; ++i) {
-        usleep(1000);
+        usleep(1000 * 1000);
         braft::Configuration new_conf;
         new_conf.add_peer("127.0.0.1:" + std::to_string(9500 + i));
         st = braft::cli::change_peers("test", conf, new_conf, braft::cli::CliOptions());
         ASSERT_TRUE(st.ok()) << st;
     }
+    usleep(1000 * 1000);
     st = braft::cli::change_peers("test", conf, conf, braft::cli::CliOptions());
     ASSERT_TRUE(st.ok()) << st;
     for (size_t i = 0; i < N; ++i) {
@@ -188,7 +189,7 @@ TEST_F(CliTest, change_peer) {
         LOG(WARNING) << "change " << conf << " to " << new_conf;
         st = braft::cli::change_peers("test", conf, new_conf, braft::cli::CliOptions());
         ASSERT_TRUE(st.ok()) << st;
-        usleep(10 * 1000);
+        usleep(1000 * 1000);
         LOG(WARNING) << "change " << new_conf << " to " << conf;
         st = braft::cli::change_peers("test", new_conf, conf, braft::cli::CliOptions());
         ASSERT_TRUE(st.ok()) << st << " i=" << i;

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -811,6 +811,19 @@ TEST_F(LogStorageTest, large_entry) {
     entry = storage->get_entry(1);
     ASSERT_EQ(data, entry->data.to_string());
     entry->Release();
+
+    ASSERT_EQ(1, storage->_first_log_index); 
+    ASSERT_EQ(1, storage->_last_log_index);
+    ASSERT_EQ(0, storage->_segments.size());
+    scoped_refptr<braft::Segment> segment = storage->open_segment(); 
+    ASSERT_EQ(1, storage->_segments.size());
+
+    braft::SegmentLogStorage* storage2 = new braft::SegmentLogStorage("./data");
+    braft::ConfigurationManager* configuration_manager2 = new braft::ConfigurationManager;
+    ASSERT_EQ(0, storage2->init(configuration_manager2));
+    ASSERT_EQ(1, storage2->_first_log_index); 
+    ASSERT_EQ(1, storage2->_last_log_index);
+    ASSERT_EQ(1, storage2->_segments.size());
 }
 
 TEST_F(LogStorageTest, reboot_with_checksum_type_changed) {

--- a/test/test_snapshot.cpp
+++ b/test/test_snapshot.cpp
@@ -609,7 +609,7 @@ TEST_F(SnapshotTest, snapshot_throttle_for_reading) {
     }
     // create and set snapshot throttle
     braft::ThroughputSnapshotThrottle* throttle = new 
-        braft::ThroughputSnapshotThrottle(30, 10);
+        braft::ThroughputSnapshotThrottle(60, 10);
     ASSERT_TRUE(throttle);
     ASSERT_EQ(storage1->set_snapshot_throttle(throttle), 0);
     ASSERT_EQ(0, storage1->init());
@@ -714,7 +714,7 @@ TEST_F(SnapshotTest, snapshot_throttle_for_writing) {
     }
     // create and set snapshot throttle for storage2
     braft::SnapshotThrottle* throttle = 
-        new braft::ThroughputSnapshotThrottle(10, 10);
+        new braft::ThroughputSnapshotThrottle(50, 10);
     ASSERT_TRUE(throttle);
     ASSERT_EQ(storage2->set_snapshot_throttle(throttle), 0);
     ASSERT_EQ(0, storage2->init());


### PR DESCRIPTION
it's possible that there is only one log in a segment, where first_index is equal to last_index