### PR TITLE
delete glog

### DIFF
--- a/example/atomic/CMakeLists.txt
+++ b/example/atomic/CMakeLists.txt
@@ -50,13 +50,6 @@ if((NOT GFLAGS_INCLUDE_PATH) OR (NOT GFLAGS_LIBRARY))
 endif()
 include_directories(${GFLAGS_INCLUDE_PATH})
 
-find_path(GLOG_INCLUDE_PATH glog/logging.h)
-find_library(GLOG_LIBRARY NAMES glog libglog)
-if((NOT GLOG_INCLUDE_PATH) OR (NOT GLOG_LIBRARY))
-    message(FATAL_ERROR "Fail to find glog")
-endif()
-include_directories(${GLOG_INCLUDE_PATH})
-
 execute_process(
     COMMAND bash -c "grep \"namespace [_A-Za-z0-9]\\+ {\" ${GFLAGS_INCLUDE_PATH}/gflags/gflags_declare.h | head -1 | awk '{print $2}' | tr -d '\n'"
     OUTPUT_VARIABLE GFLAGS_NS
@@ -121,7 +114,6 @@ add_executable(atomic_test test.cpp ${PROTO_SRC} ${PROTO_HEADER})
 set(DYNAMIC_LIB
     ${CMAKE_THREAD_LIBS_INIT}
     ${GFLAGS_LIBRARY}
-    ${GLOG_LIBRARY}
     ${PROTOBUF_LIBRARY}
     ${GPERFTOOLS_LIBRARIES}
     ${LEVELDB_LIB}

--- a/example/atomic/server.cpp
+++ b/example/atomic/server.cpp
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <bthread/bthread.h>
 #include <gflags/gflags.h>
-#include <glog/logging.h>
 #include <butil/containers/flat_map.h>
 #include <butil/logging.h>
 #include <bthread/bthread.h>
@@ -469,7 +468,6 @@ private:
 
 int main(int argc, char* argv[]) {
     GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
-    google::InitGoogleLogging(argv[0]);
 
     // Generally you only need one Server.
     brpc::Server server;


### PR DESCRIPTION
删除没有使用的 glog，避免在有些环境下会报执行错误：
> ERROR: flag 'v' was defined more than once (in files 'src/vlog_is_on.cc' and 'brpc/src/butil/logging.cc').