### PR TITLE
eliminate warning

### DIFF
--- a/jepsen/test/jepsen/atomic_test.clj
+++ b/jepsen/test/jepsen/atomic_test.clj
@@ -13,7 +13,8 @@
             [jepsen.generator :as gen]
             [jepsen.nemesis   :as nemesis]
             [jepsen.store     :as store]
-            [jepsen.report    :as report]))
+            [jepsen.report    :as report]
+            [jepsen.core :as jepsen]))
 
 ;(deftest partition-test
 ;  (let [test (run!
@@ -50,7 +51,7 @@
 (defn run-set-test!
   "Runs a test around set creation and dumps some results to the report/ dir"
   [t]
-  (let [test (run! t)]
+  (let [test (jepsen/run! t)]
     (is (:valid? (:results test)))
     (report/linearizability (:linear (:results test)))))
 


### PR DESCRIPTION
WARNING: run! already refers to: #'clojure.core/run! in namespace: jepsen.atomic-test, being replaced by: #'jepsen.core/run!