### PR TITLE
fix snapshot path stitching error

### DIFF
--- a/src/braft/snapshot.cpp
+++ b/src/braft/snapshot.cpp
@@ -344,7 +344,13 @@ public:
         // filename is a string like './raft/raft_snapshot/temp/block-17931339458560001'
         // but in function read_file_with_meta, std::string file_path(_path + "/" + filename);
         // _path is a string like './raft/raft_snapshot/snapshot_00000000000000000797'
-        auto pos = filename.rfind('/');
+        auto pos = LocalDirReader::path().rfind('/');
+        if (pos != std::string::npos) {
+            auto parent = LocalDirReader::path().substr(0, pos + 1);
+            if (filename.find(parent) == 0) {
+                filename = filename.substr(parent.size());
+            }
+        }
 
         // go through throttle
         size_t new_max_count = max_count;
@@ -361,8 +367,7 @@ public:
                 }
             }
             if (ret == 0) {
-                ret = LocalDirReader::read_file_with_meta(
-                    out, (pos != std::string::npos) ? filename.substr(pos + 1) : filename,
+                ret = LocalDirReader::read_file_with_meta(out, filename,
                     &file_meta, offset, new_max_count, read_count, is_eof);
                 used_count = out->size();
             }
@@ -372,8 +377,7 @@ public:
             }
             return ret;
         }
-        return LocalDirReader::read_file_with_meta(
-            out, (pos != std::string::npos) ? filename.substr(pos + 1) : filename,
+        return LocalDirReader::read_file_with_meta(out, filename,
             &file_meta, offset, new_max_count, read_count, is_eof);
     }
    

--- a/src/braft/snapshot.cpp
+++ b/src/braft/snapshot.cpp
@@ -340,15 +340,13 @@ public:
             return EPERM;
         }
 
-        // FIX: not such file or directory
-        // filename is a string like './raft/raft_snapshot/temp/block-17931339458560001'
-        // but in function read_file_with_meta, std::string file_path(_path + "/" + filename);
-        // _path is a string like './raft/raft_snapshot/snapshot_00000000000000000797'
+        // maybe filename and _path have the same parent directory
+        auto file_name(filename);
         auto pos = LocalDirReader::path().rfind('/');
         if (pos != std::string::npos) {
             auto parent = LocalDirReader::path().substr(0, pos + 1);
             if (filename.find(parent) == 0) {
-                filename = filename.substr(parent.size());
+                file_name = filename.substr(parent.size());
             }
         }
 
@@ -367,7 +365,7 @@ public:
                 }
             }
             if (ret == 0) {
-                ret = LocalDirReader::read_file_with_meta(out, filename,
+                ret = LocalDirReader::read_file_with_meta(out, file_name,
                     &file_meta, offset, new_max_count, read_count, is_eof);
                 used_count = out->size();
             }
@@ -377,7 +375,7 @@ public:
             }
             return ret;
         }
-        return LocalDirReader::read_file_with_meta(out, filename,
+        return LocalDirReader::read_file_with_meta(out, file_name,
             &file_meta, offset, new_max_count, read_count, is_eof);
     }
    


### PR DESCRIPTION
我在测试快照网络同步时leader这边出现在FileServiceImpl::get_file中读取文件失败，错误描述是Not such file or directory。查看源代码后，发现在SnapshotFileReader::read_file函数中，meta表中的数据是类似 “./raft/raft_snapshot/temp/block-17931339458560001”的相对路径，进入LocalDirReader::read_file_with_meta函数后，_path是"./raft/raft_snapshot/snapshot_00000000000000000797"。所以直接用"/"拼接在一起，就导致此错误出现。

上述路径都是我部署的实际测试路径.