### PR TITLE
fix fatal error: Check failed: false. Tried to RegisterCallback witho…

### DIFF
--- a/example/block/server.cpp
+++ b/example/block/server.cpp
@@ -466,6 +466,7 @@ private:
 
 int main(int argc, char* argv[]) {
     GFLAGS_NS::ParseCommandLineFlags(&argc, &argv, true);
+    butil::AtExitManager exit_manager;
 
     // Generally you only need one Server.
     brpc::Server server;


### PR DESCRIPTION
…ut an AtExitManager

update server.cpp, fix a  fatal error log:
src/butil/at_exit.cc:46] Check failed: false. Tried to RegisterCallback without an AtExitManager