### PR TITLE
fix log truncate_suffix bug

### DIFF
--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -202,6 +202,7 @@ private:
     int load_meta();
     int list_segments(bool is_empty);
     int load_segments(ConfigurationManager* configuration_manager);
+    int check_segments();
     int get_segment(int64_t log_index, scoped_refptr<Segment>* ptr);
     void pop_segments(
             int64_t first_index_kept, 


### PR DESCRIPTION
1. truncate_suffix order must be from back to front, otherwise it can break log matching property of raft.
For example, considering five servers.
(server #: terms of logs)
server 1: ...9 10 10 10
server 2: ...9 11 11
server 3: ...9 
server 4: ...9 
server 5: ...9 10 10 10
Now server 2 is a leader with term 11 and send AppendEntries rpc to server 1. If server 1 crash while truncating from front to back, log can be 9 (empty) (empty) 10.
And then server 2 crash. server 5 get server 3 and 4's vote and become a leader with term 12.
Afterward server 1 come back to life. Server 5 send AppendEntries rpc to 1 and find the last matching log and add a log with term 12.
server 1: ...9 (empty) (empty) 10 12
server 2: ...9 11 11(crashed)
server 3: ...9 10 10 10 12
server 4: ...9 10 10 10 12
server 5: ...9 10 10 10 12
Server 5 think the first log with term 12 can be committed.
Unfortunately, server 1's log will have the hole forever.
The truncate suffix order in original code is that the unique last-need-truncated segment first, and then unlink latter segments from back to front.
Although the unit is a segment not a log, it has the same problem.
In original code, previous example may lead to server 1 can't revive because of checking validity of segments(e.g. the log sequence number is not continuous).
However it's not enough just to check index from file name. Crash may happen before renaming the corresponding file. In this case, server 1 revive but may crash on any call to get its empty log Entry(_offset_and_term vector out of range in Segment::get_meta).
l have added code in Segment::load to repair last index in file name and moved check_segments after load_segments.

2. Rename failure in Segment::truncate should return error, otherwise next time rename(add .tmp) in unlink or truncate will fail because _last_index in memory is not consistent with its file name.

3. In SegmentLogStorage::pop_segments_from_back, l think it make no sense to set _first_log_index if all segments need to be deleted because the meaningful interval of last_index_kept should be [_first_log_index -1, _last_log_index](last_index_kept = _first_log_index - 1, so set _first_log_index = last_index_kept + 1 is no use). To say the least, if it does make sense to set _first_log_index, save_meta should called to save right _first_log_index to disk. This confused me, so l didn't change it.

l am sorry for not adding unit test for my code because unit test is hard to check above problems.