### PR TITLE
Simplify and clarify cmake script and build instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,12 @@ endif()
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(FindThreads)
-include(FindProtobuf)
+
+find_path(PROTOBUF_INCLUDE_PATH NAMES google/protobuf/message.h)
+find_library(PROTOBUF_LIB NAMES libprotobuf.a protobuf)
+if ((NOT PROTOBUF_INCLUDE_PATH) OR (NOT PROTOBUF_LIB))
+    message(FATAL_ERROR "Fail to find protobuf")
+endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # require at least gcc 4.8
@@ -73,57 +78,51 @@ if ((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
 endif()
 
 if (NOT PROTOBUF_PROTOC_EXECUTABLE)
-    get_filename_component(PROTO_LIB_DIR ${PROTOBUF_LIBRARY} DIRECTORY)
+    get_filename_component(PROTO_LIB_DIR ${PROTOBUF_LIB} DIRECTORY)
     set (PROTOBUF_PROTOC_EXECUTABLE "${PROTO_LIB_DIR}/../bin/protoc")
 endif()
 
+# the default openssl installation path differs between mac and linux
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(OPENSSL_ROOT_DIR
-        "/usr/local/opt/openssl"    # Homebrew installed OpenSSL
-        )
+    if (NOT OPENSSL_ROOT_DIR)
+        set(OPENSSL_ROOT_DIR
+            "/usr/local/opt/openssl" # Homebrew installed OpenSSL
+            )
+    endif()
 endif()
 
 include(FindOpenSSL)
 
 include_directories(
         ${GFLAGS_INCLUDE_PATH}
-        ${PROTOBUF_INCLUDE_DIRS}
+        ${PROTOBUF_INCLUDE_PATH}
         ${LEVELDB_INCLUDE_PATH}
         ${BRPC_INCLUDE_PATH}
         ${OPENSSL_INCLUDE_DIR}
         )
 
+set(DYNAMIC_LIB
+    ${BRPC_LIB}
+    ${GFLAGS_LIB}
+    ${PROTOBUF_LIB}
+    ${LEVELDB_LIB}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${OPENSSL_LIBRARIES}
+    ${OPENSSL_CRYPTO_LIBRARY}
+    dl
+    z
+)
+
 if(BRPC_WITH_GLOG)
-    set(DYNAMIC_LIB
-        ${BRPC_LIB}
-        ${GFLAGS_LIB}
+    set(DYNAMIC_LIB ${DYNAMIC_LIB}
         ${GLOG_LIB}
-        ${PROTOBUF_LIBRARY}
-        ${LEVELDB_LIB}
-        ${CMAKE_THREAD_LIBS_INIT}
-        ${OPENSSL_LIBRARIES}
-        ${OPENSSL_CRYPTO_LIBRARY}
-        dl
-        z
         )
-else()
-    set(DYNAMIC_LIB
-        ${BRPC_LIB}
-        ${GFLAGS_LIB}
-        ${PROTOBUF_LIBRARY}
-        ${LEVELDB_LIB}
-        ${CMAKE_THREAD_LIBS_INIT}
-        ${OPENSSL_LIBRARIES}
-        ${OPENSSL_CRYPTO_LIBRARY}
-        dl
-        z
-	)
 endif()
 
 if(LEVELDB_WITH_SNAPPY)
     set(DYNAMIC_LIB ${DYNAMIC_LIB}
         ${SNAPPY_LIB}
-	)
+        )
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
@@ -157,7 +156,7 @@ foreach(PROTO ${BRAFT_PROTOS})
     execute_process(
         COMMAND ${PROTOBUF_PROTOC_EXECUTABLE} ${PROTO_FLAGS}
         --cpp_out=${CMAKE_CURRENT_BINARY_DIR}
-        --proto_path=${PROTOBUF_INCLUDE_DIR}
+        --proto_path=${PROTOBUF_INCLUDE_PATH}
         --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/src
         --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/src/braft/ ${PROTO}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/README.md
+++ b/README.md
@@ -11,15 +11,40 @@ It's widely used inside Baidu to build highly-available systems, such as:
 
 # Getting Started
 
-* Build [brpc](https://github.com/brpc/brpc/blob/master/docs/cn/getting_started.md) which is the main dependency of braft.
+1. braft mainly depends on brpc, which depends on openssl, protobuffer,
+	leveldb, gflags and glog, make sure you have all the dependencies installed
+	before building braft
 
-* Compile braft with cmake
+2. Build [brpc](https://github.com/brpc/brpc/blob/master/docs/cn/getting_started.md),
+	once brpc built successfully you are just one small step away from building
+	braft successfully
 
-  ```shell
-  $ mkdir bld && cd bld && cmake .. && make
-  ```
+3. Compile braft with cmake, **remember to change paths to deps respectively**,
+	the build result is in folder named `output`
 
-* Play braft with [examples](./example).
+	```shell
+	$ mkdir build-dir && cd build-dir
+	$ cmake .. \
+		-DOPENSSL_ROOT_DIR:PATH=path/to/openssl \
+		-DPROTOBUF_INCLUDE_PATH:PATH=path/to/protobuffer/include/ \
+		-DPROTOBUF_LIB:PATH=path/to/protobuffer/lib/libprotobuf.a \
+		-DLEVELDB_INCLUDE_PATH:PATH=path/to/leveldb/include \
+		-DLEVELDB_LIB:PATH=path/to/leveldb/libs/libleveldb.a \
+		-DGFLAGS_INCLUDE_PATH:PATH=path/to/gflags/include \
+		-DGFLAGS_LIB:PATH=path/to/gflags/libs/libgflags.a \
+		-DBRPC_INCLUDE_PATH:PATH=path/to/brpc/include \
+		-DBRPC_LIB:PATH=path/to/brpc/lib/libbrpc.a \
+		-DBRPC_WITH_GLOG=ON \
+		-DGLOG_INCLUDE_PATH:PATH=path/to/glog/include \
+		-DGLOG_LIB:PATH=path/to/glog/libs/libglog.a
+	```
+
+	in which:
+	* glog is optional, but it's no harm to build with it
+	* If there is any confusion about openssl, check [this issue](https://github.com/apache/incubator-brpc/pull/770)
+		for more detail
+
+4. Play braft with [examples](./example).
 
 # Docs
 


### PR DESCRIPTION
Replace `include(FindProtobuf)` with "manual detection" of protobuffer because:

1. We can make the names of dependencies consistent in a form of
   `XXX_INCLUDE_PATH` and `XXX_LIB`.
   Before replacing, we may have to provide `Protobuf_INCLUDE_DIR` and
   `Protobuf_LIBRARY` too, which is inconsistent with other libs.
2. If the protoc's version, the protoc is detected by `include(FindProtobuf)`,
   is different (there are several versions installed) from the libprotobuf
   provided, it may lead to version inconsistency.